### PR TITLE
use single instead of archive layout

### DIFF
--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -1,5 +1,5 @@
 ---
-layout: archive
+layout: single
 ---
 
 {{ content }}


### PR DESCRIPTION
to avoid empty parenthesis at the top of the list of all posts